### PR TITLE
fix:全問正解時、すぐにfinishedをtrueに変更

### DIFF
--- a/src/store/QuizeProgressCounter.ts
+++ b/src/store/QuizeProgressCounter.ts
@@ -15,8 +15,9 @@ export const useProgressCounterStore = defineStore('ProgressCounter', () => {
     function Increment() {
       if (ProgressCount.value < quizeLen) {
         ProgressCount.value++
-      } else {
-        isQuizeFinished.value = true;
+        if(ProgressCount.value == quizeLen) {
+          isQuizeFinished.value = true;
+        }
       }
     }
 


### PR DESCRIPTION
全問正解時、即時に'/finish'に移動するようにしました。

QuizeProgressCounter.ts 15 ~ 21行目が変更箇所です。

多分どこにも影響はありません